### PR TITLE
Speedup multivariate GCD in finite fields for coprime input

### DIFF
--- a/rings/src/main/java/cc/redberry/rings/poly/multivar/MultivariatePolynomial.java
+++ b/rings/src/main/java/cc/redberry/rings/poly/multivar/MultivariatePolynomial.java
@@ -863,6 +863,8 @@ public final class MultivariatePolynomial<E> extends AMultivariatePolynomial<Mon
      * #eliminate(int, long)})
      */
     MultivariatePolynomial<E> evaluate(int variable, PrecomputedPowers<E> powers) {
+        if (degree(variable) == 0)
+            return clone();
         if (ring.isZero(powers.value))
             return evaluateAtZero(variable);
         MonomialSet<Monomial<E>> newData = new MonomialSet<>(ordering);
@@ -1372,6 +1374,8 @@ public final class MultivariatePolynomial<E> extends AMultivariatePolynomial<Mon
 
     @Override
     public MultivariatePolynomial<E> evaluateAtRandomPreservingSkeleton(int variable, RandomGenerator rnd) {
+        if (degree(variable) == 0)
+            return clone();
         //desired skeleton
         Set<DegreeVector> skeleton = getSkeletonExcept(variable);
         MultivariatePolynomial<E> tmp;

--- a/rings/src/main/java/cc/redberry/rings/poly/multivar/MultivariatePolynomialZp64.java
+++ b/rings/src/main/java/cc/redberry/rings/poly/multivar/MultivariatePolynomialZp64.java
@@ -798,6 +798,8 @@ public final class MultivariatePolynomialZp64 extends AMultivariatePolynomial<Mo
      * #eliminate(int, long)})
      */
     MultivariatePolynomialZp64 evaluate(int variable, lPrecomputedPowers powers) {
+        if (degree(variable) == 0)
+            return clone();
         if (powers.value == 0)
             return evaluateAtZero(variable);
         MonomialSet<MonomialZp64> newData = new MonomialSet<>(ordering);

--- a/rings/src/test/java/cc/redberry/rings/poly/multivar/MultivariateGCDTest.java
+++ b/rings/src/test/java/cc/redberry/rings/poly/multivar/MultivariateGCDTest.java
@@ -1255,7 +1255,6 @@ public class MultivariateGCDTest extends AMultivariateTest {
                 GCDAlgorithm.named("Modular gcd (small cardinality)", MultivariateGCD::ModularGCDInGF));
     }
 
-
     @Test
     public void testSmallDomain2() throws Exception {
         IntegersZp64 domain = new IntegersZp64(3);


### PR DESCRIPTION
Significantly speedup multivariate GCD in finite fields for coprime input.

Speedup achieved by imposing more comprehensive degree bounds on the resulting gcd. Additional restrictions on degree bounds came from several randomized univariate gcd tests (substitute all but one variables with random values).