### PR TITLE
Added possibility to cache all modular inverses for small finite fields.

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -197,6 +197,43 @@ It is worst to mention, that multiplication defined in `IntegersZp64`_ is especi
 .. _IntegersZp: http://javadoc.io/page/cc.redberry/rings/latest/cc/redberry/IntegersZp.html
 
 
+When doing a lot of operations in a fixed finite field with small cardinality, it is recommended to precompute all modular inverses. This way division in the field become as fast as multiplication. Example:
+
+
+.. tabs::
+
+   .. code-tab:: java
+
+        IntegersZp64 zp = new IntegersZp64(modulus);
+        // build complete table
+        zp.buildCachedReciprocals();
+        // takes zero time
+        zp.reciprocal(123);
+
+
+        // if polynomial ring is given
+        UnivariateRing<UnivariatePolynomialZp64> pRing = Rings.UnivariateRingZp64(17);
+        // the same instance of coefficient ring is used for all polynomials
+        // one can access it using any polynomial instance
+        pRing.factory().ring.buildCachedReciprocals();
+
+
+   .. code-tab:: scala
+
+        val zp = Zp64(modulus)
+        // build complete table
+        zp.buildCachedReciprocals()
+
+        // if polynomial ring is given
+        val pRing = UnivariateRingZp64(modulus, "x")
+        // the same instance of coefficient ring is used for all polynomials
+        // one can access it using any polynomial instance
+        pRing.factory().ring.buildCachedReciprocals()
+
+
+Precomputing table of inverses is not done by default even for very small fields, to avoid huge memory consumtion when many instances with different primes are allocated (often case).
+
+
 .. admonition:: Full API documentation
 
     * API docs for ``IntegersZp64``: `cc.redberry.rings.IntegersZp64 <http://javadoc.io/page/cc.redberry/rings/latest/cc/redberry/rings/IntegersZp64.html>`_

--- a/rings/src/test/java/cc/redberry/rings/IntegersZp64Test.java
+++ b/rings/src/test/java/cc/redberry/rings/IntegersZp64Test.java
@@ -1,0 +1,38 @@
+package cc.redberry.rings;
+
+import cc.redberry.rings.primes.SmallPrimes;
+import cc.redberry.rings.util.TimeUnits;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class IntegersZp64Test {
+
+    @Test
+    @Ignore
+    public void test1() {
+        for (int k = 0; k < 1000; ++k) {
+            IntegersZp64 zp = new IntegersZp64(SmallPrimes.nextPrime(10000 + k));
+            long start = System.nanoTime();
+            long sum1 = 0;
+            for (int i = 1; i < zp.modulus; ++i)
+                sum1 += zp.reciprocal(i);
+            long el1 = System.nanoTime() - start;
+
+            zp.buildCachedReciprocals();
+            start = System.nanoTime();
+            long sum2 = 0;
+            for (int i = 1; i < zp.modulus; ++i)
+                sum2 += zp.reciprocal(i);
+            long el2 = System.nanoTime() - start;
+
+            System.out.println("no cache: " + TimeUnits.nanosecondsToString(el1));
+            System.out.println("   cache: " + TimeUnits.nanosecondsToString(el2));
+            System.out.println();
+            Assert.assertEquals(sum1, sum2);
+        }
+    }
+}


### PR DESCRIPTION
Useful for relatively small `Zp64` fields. Usage example:
```java
IntegersZp64 zp = new IntegersZp64(modulus);
// build complete table
zp.buildCachedReciprocals();
// takes zero time
zp.reciprocal(123);
```

Build cache when polynomial ring is given:
```java
UnivariateRing<UnivariatePolynomialZp64> pRing = Rings.UnivariateRingZp64(17);
// the same instance of coefficient ring is used for all polynomials
// one can access it using any polynomial instance
pRing.factory().ring.buildCachedReciprocals();
```

In Scala:
```scala
val zp = Zp64(modulus)
// build complete table
zp.buildCachedReciprocals()

val pRing = UnivariateRingZp64(modulus, "x")
// the same instance of coefficient ring is used for all polynomials
// one can access it using any polynomial instance
pRing.factory().ring.buildCachedReciprocals()
```

The feature is not turned on by default even for very small fields, to avoid OOM when many instances with different primes are allocated (quite often case).

This addresses #57.